### PR TITLE
Fixed segfault && data comunication bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# C++ objects and libs
+
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+qrc_*.cpp
+ui_*.h
+Makefile*
+*build-*
+
+# QtCreator
+
+*.autosave
+
+#QtCtreator Qml
+*.qmlproject.user
+*.qmlproject.user.*

--- a/radeon-profile-daemon/radeon-profile-daemon.pro
+++ b/radeon-profile-daemon/radeon-profile-daemon.pro
@@ -12,6 +12,14 @@ TARGET = radeon-profile-daemon
 CONFIG   += console
 CONFIG   -= app_bundle
 
+#   https://forum.qt.io/topic/10178/solved-qdebug-and-debug-release/2
+#   http://doc.qt.io/qt-5/qtglobal.html#QtMsgType-enum
+#   qDebug will work only when compiled for Debug
+#   QtWarning, QtCritical and QtFatal will work also on Release
+@
+CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
+@
+
 TEMPLATE = app
 
 

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -86,12 +86,14 @@ void rpdThread::performTask(const QString &signal) {
                     system(QString("cp "+ clocksDataPath + " /tmp/").toStdString().c_str());
 
                 // if timer interval also comes in, configure it
-                if(size == 3)
-                    performTask(s[2]);
-                else if(size == 4)
-                    performTask(s[2]+s[3]);
-                else
-                    qCritical() << "Too much instructions in one signal";
+                if(size > 2){
+                    if(size == 3)
+                        performTask(s[2]);
+                    else if(size == 4)
+                        performTask(s[2]+s[3]);
+                    else
+                        qCritical() << "Too much instructions in one signal";
+                }
             }else{
                 qWarning() << "Received a malformed signal: " << signal;
             }

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -41,7 +41,7 @@ void rpdThread::newConn() {
 void rpdThread::disconnected() {
     qWarning() << "disconnect";
     timer->stop();
-    sharedMem.detach();
+//    sharedMem.detach();
 }
 
 

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -78,7 +78,7 @@ void rpdThread::performTask(const QString &signal) {
         switch (decodedSignal[0].toLatin1()) {
         case SIGNAL_CONFIG: {
             qDebug() << "Elaborating a CONFIG signal";
-            QStringList s = decodedSignal.split("#",QString::SkipEmptyParts);
+            QStringList s = decodedSignal.split(SEPARATOR,QString::SkipEmptyParts);
             int size=s.size();
             if(size > 1){
                 QString filePath=s[1]; // The file path is after the '#'
@@ -120,7 +120,7 @@ void rpdThread::performTask(const QString &signal) {
             qDebug() << "Elaborating a SET_VALUE signal";
             // when two singlans have been sent one after another instantly, they comes as one singal to daemon
             // so this is handling such things. # and later split, and later dealing with it in while...
-            QStringList s = decodedSignal.split("#",QString::SkipEmptyParts);
+            QStringList s = decodedSignal.split(SEPARATOR,QString::SkipEmptyParts);
             int sIdx =0, // singal index
                 pIdx = 1; // path index
             while (pIdx < s.count()) {
@@ -131,7 +131,7 @@ void rpdThread::performTask(const QString &signal) {
         break;
         case SIGNAL_TIMER_ON:{            
             qDebug() << "Elaborating a TIMER_ON signal";
-            QString input=decodedSignal.remove(0,1); // Seconds string
+            QString input=decodedSignal.remove(0,1).remove(SEPARATOR); // Seconds string
             int inputMillis=input.toInt(); // Seconds integer
             if(inputMillis > 0){ // If seconds have been parsed correctly and the value is valid
                 qDebug() << "Setting up timer with seconds interval: " << inputMillis;

--- a/radeon-profile-daemon/rpdthread.h
+++ b/radeon-profile-daemon/rpdthread.h
@@ -21,6 +21,7 @@
 #include <QSharedMemory>
 #include <QTimer>
 
+#define SEPARATOR '#'
 #define SIGNAL_CONFIG '0'
 #define SIGNAL_READ_CLOCKS '1'
 #define SIGNAL_SET_VALUE '2'

--- a/radeon-profile-daemon/rpdthread.h
+++ b/radeon-profile-daemon/rpdthread.h
@@ -28,6 +28,8 @@
 #define SIGNAL_TIMER_ON '4'
 #define SIGNAL_TIMER_OFF '5'
 
+#define SHARED_MEM_SIZE 128 // When changing this, also change SHARED_MEM_SIZE in radeon-profile/dxorg.h
+
 const QString serverName = "radeon-profile-daemon-server";
 
 class rpdThread : public QThread

--- a/radeon-profile-daemon/rpdthread.h
+++ b/radeon-profile-daemon/rpdthread.h
@@ -37,6 +37,7 @@ public:
     ~rpdThread() {
         delete signalReceiver;
         delete daemonServer;
+        delete timer;
     }
 
 signals:

--- a/radeon-profile-daemon/rpdthread.h
+++ b/radeon-profile-daemon/rpdthread.h
@@ -21,6 +21,12 @@
 #include <QSharedMemory>
 #include <QTimer>
 
+#define SIGNAL_CONFIG '0'
+#define SIGNAL_READ_CLOCKS '1'
+#define SIGNAL_SET_VALUE '2'
+#define SIGNAL_TIMER_ON '4'
+#define SIGNAL_TIMER_OFF '5'
+
 const QString serverName = "radeon-profile-daemon-server";
 
 class rpdThread : public QThread


### PR DESCRIPTION
Fixed an unchecked array access that caused a segfault of the daemon when the app was launched, in *rpdthread.cpp* at line 84. This solves the issue #2 .
Fixed a QString -> char[] conversion error that prevented the daemon from sending data to the main radeon-profile app, in *rpdthread.cpp* at line 129. 
Improved the logging system: now *qDebug* messages will only be shown when the daemon is compiled with the debug flag, while *qWarning*, *qCritical* and *qFatal* will behave the same way as before.
Moved the signal types into *rpdthread.h* as constants (it's more clear now).
Added *.gitignore* file, useful for git.