### PR TITLE
Check if all arguments used by each instruction are valid

### DIFF
--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -86,11 +86,11 @@ void rpdThread::performTask(const QString &signal) {
 
                 // SIGNAL_CONFIG + SEPARATOR + CLOCKS_PATH + SEPARATOR
             case SIGNAL_CONFIG:
-                qDebug() << "Elaborating a CONFIG signal";
                 if (index >= (size - 1)) {
-                    qWarning() << "Received a SIGNAL_CONFIG signal with no path: " << signal;
+                    qWarning() << "Received a CONFIG signal with no path: " << signal;
                     break;
                 }
+                qDebug() << "Elaborating a CONFIG signal";
 
                 if (!configure(instructions[++index]))
                     qWarning() << "Configuration failed.";
@@ -105,16 +105,15 @@ void rpdThread::performTask(const QString &signal) {
 
                 // SIGNAL_SET_VALUE + SEPARATOR + VALUE + SEPARATOR + PATH + SEPARATOR
             case SIGNAL_SET_VALUE: {
-                qDebug() << "Elaborating a SET_VALUE signal";
                 if (index == (size - 2)) {
                     qWarning() << "Received a SET_VALUE signal with no path: " << signal;
                     break;
                 }
-
                 if (index >= (size - 1)) {
                     qWarning() << "Received a SET_VALUE signal with no value: " << signal;
                     break;
                 }
+                qDebug() << "Elaborating a SET_VALUE signal";
 
                 const QString value = instructions[++index],
                         path = instructions[++index];
@@ -126,11 +125,11 @@ void rpdThread::performTask(const QString &signal) {
                 // SIGNAL_TIMER_ON + SEPARATOR + INTERVAL + SEPARATOR
             case SIGNAL_TIMER_ON: {
                 if (index >= (size - 1)) {
-                    qWarning() << "Received a SIGNAL_TIMER_ON signal with no interval: " << signal;
+                    qWarning() << "Received a TIMER_ON signal with no interval: " << signal;
                     break;
                 }
-
                 qDebug() << "Elaborating a TIMER_ON signal";
+
                 int inputMillis = instructions[++index].toInt(); // Seconds integer
 
                 if (inputMillis < 1) {
@@ -151,15 +150,17 @@ void rpdThread::performTask(const QString &signal) {
 
             case SIGNAL_SHAREDMEM_KEY: {
                 if (index >= (size - 1)) {
-                    qWarning() << "Received a SIGNAL_SHAREDMEM_KEY signal with no key: " << signal;
+                    qWarning() << "Received a SHAREDMEM_KEY signal with no key: " << signal;
                     break;
                 }
+                qDebug() << "Elaborating a SHAREDMEM_KEY signal";
 
                 QString key = instructions[++index];
                 qDebug() << "Shared memory key: " << key;
                 configureSharedMem(key);
                 break;
             }
+
             default:
                 qWarning() << "Unknown signal received: " << signal;
                 break;

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -76,6 +76,10 @@ void rpdThread::performTask(const QString &signal) {
 
     // Cycle through instructions
     for (int index = 0; index < size; index++) {
+        if(instructions[index].isEmpty()){
+            qWarning() << "Received empty instruction, skipping";
+            continue;
+        }
 
         // Check the first char (instruction type)
         switch (instructions[index][0].toLatin1()) {
@@ -83,6 +87,10 @@ void rpdThread::performTask(const QString &signal) {
                 // SIGNAL_CONFIG + SEPARATOR + CLOCKS_PATH + SEPARATOR
             case SIGNAL_CONFIG:
                 qDebug() << "Elaborating a CONFIG signal";
+                if (index >= (size - 1)) {
+                    qWarning() << "Received a SIGNAL_CONFIG signal with no path: " << signal;
+                    break;
+                }
 
                 if (!configure(instructions[++index]))
                     qWarning() << "Configuration failed.";
@@ -98,8 +106,13 @@ void rpdThread::performTask(const QString &signal) {
                 // SIGNAL_SET_VALUE + SEPARATOR + VALUE + SEPARATOR + PATH + SEPARATOR
             case SIGNAL_SET_VALUE: {
                 qDebug() << "Elaborating a SET_VALUE signal";
-                if (index > (size - 1)) {
+                if (index == (size - 2)) {
                     qWarning() << "Received a SET_VALUE signal with no path: " << signal;
+                    break;
+                }
+
+                if (index >= (size - 1)) {
+                    qWarning() << "Received a SET_VALUE signal with no value: " << signal;
                     break;
                 }
 
@@ -112,6 +125,11 @@ void rpdThread::performTask(const QString &signal) {
 
                 // SIGNAL_TIMER_ON + SEPARATOR + INTERVAL + SEPARATOR
             case SIGNAL_TIMER_ON: {
+                if (index >= (size - 1)) {
+                    qWarning() << "Received a SIGNAL_TIMER_ON signal with no interval: " << signal;
+                    break;
+                }
+
                 qDebug() << "Elaborating a TIMER_ON signal";
                 int inputMillis = instructions[++index].toInt(); // Seconds integer
 
@@ -132,6 +150,11 @@ void rpdThread::performTask(const QString &signal) {
                 break;
 
             case SIGNAL_SHAREDMEM_KEY: {
+                if (index >= (size - 1)) {
+                    qWarning() << "Received a SIGNAL_SHAREDMEM_KEY signal with no key: " << signal;
+                    break;
+                }
+
                 QString key = instructions[++index];
                 qDebug() << "Shared memory key: " << key;
                 configureSharedMem(key);

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -76,10 +76,6 @@ void rpdThread::performTask(const QString &signal) {
 
     // Cycle through instructions
     for (int index = 0; index < size; index++) {
-        if(instructions[index].isEmpty()){
-            qWarning() << "Received empty instruction, skipping";
-            continue;
-        }
 
         // Check the first char (instruction type)
         switch (instructions[index][0].toLatin1()) {
@@ -148,6 +144,7 @@ void rpdThread::performTask(const QString &signal) {
                 timer->stop();
                 break;
 
+                // SIGNAL_SHAREDMEM_KEY + SEPARATOR + KEY + SEPARATOR
             case SIGNAL_SHAREDMEM_KEY: {
                 if (index >= (size - 1)) {
                     qWarning() << "Received a SHAREDMEM_KEY signal with no key: " << signal;


### PR DESCRIPTION
Without these fixes using rp-dev branch ( i think after https://github.com/marazmista/radeon-profile/commit/557aaa666ca245c53a1de46738ca0c8b168909af ) makes the daemon crash when the user checks/unchecks the "Use daemon as data provider" and closes the application. 
This is because [it sends to the daemon `2#0##2#0##`](https://user-images.githubusercontent.com/8406735/27735503-40a7a108-5da0-11e7-92d6-92d3d68a8ddc.png), a SIGNAL_SET_VALUE with empty path which gets discarded (in because in line 74 split() uses QString::SkipEmptyParts ) and so "2" is used as path (later rejected in setNewValue() as invalid) and the next instruction is interpreted as SIGNAL_CONFIG so the daemon proceeds to fetch the path, which has also been discarded as empty, and a segmentation fault occurs.
NOTE: This only prevents radeon-profile-daemon from crashing. It is still necessary to fix radeon-profile, because the signal it sends is still malformed.