### PR TITLE
Updated the gitignore, removed bad entries in the systemd service file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,14 @@
 
 /.qmake.cache
 /.qmake.stash
+radeon-profile-daemon/.qmake.stash
 *.pro.user
 *.pro.user.*
 *.qbs.user
 *.qbs.user.*
 *.moc
 moc_*.cpp
+moc_*.h
 qrc_*.cpp
 ui_*.h
 Makefile*
@@ -32,3 +34,6 @@ Makefile*
 #QtCtreator Qml
 *.qmlproject.user
 *.qmlproject.user.*
+
+# Binary
+radeon-profile-daemon/radeon-profile-daemon

--- a/radeon-profile-daemon/extra/radeon-profile-daemon.service
+++ b/radeon-profile-daemon/extra/radeon-profile-daemon.service
@@ -4,8 +4,6 @@ Description=radeon-profile daemon
 [Service]
 Type=simple
 ExecStart=/usr/bin/radeon-profile-daemon
-ExecStop=/usr/bin/killall radeon-profile-daemon
-ExecReload=/usr/bin/killall radeon-profile-daemon && /usr/bin/radeon-profile-daemon
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've added some entries to the gitignore that were required after building the project.

I've also removed some entries from the systemd service file:

- `ExecStop=/usr/bin/killall radeon-profile-daemon`
    - SystemD sends a SIGTERM by default to processes when a user runs `systemctl stop $service`
- `ExecReload=/usr/bin/killall radeon-profile-daemon && /usr/bin/radeon-profile-daemon`
    - If you want to restart a service, you should run `systemctl restart $service`. ExecReload is used for reloading the configuration of a service.
